### PR TITLE
~Tweaked error message display

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,11 @@
 [x] Primitive types using non-linear type system for easier use
 [x] Basic automatic test suite
 [x] Typecasting of primitive types
+[x] Implemented if statements
+[x] Clearer Error logs. Embeds code snippet with line ref
 
 ### Fixes
+[x] Fixed strings requiring pointer types
 
 ### Tweaks
+[x] Internal representation of LLVM-IR now allows for latent code branches (sections of code which can be enabled after initial compilation)

--- a/compiler/component/file.js
+++ b/compiler/component/file.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const BNF = require('bnf-parser');
 
+const helper = require('../helper/error.js');
+
 const LLVM = require('./../middle/llvm.js');
 const Function = require('./function.js');
 const TypeDef  = require('./typedef.js');
@@ -241,14 +243,9 @@ class File {
 	}
 
 	throw (msg, refStart, refEnd) {
-		let area = BNF.Message.HighlightArea(this.data, refStart, refEnd);
-		console.error(`\n${this.path}:`);
-		if (refEnd) {
-			console.error(`${msg} ${refStart.toString()} -> ${refEnd.toString()}`);
-		} else {
-			console.error(`${msg} ${refStart.toString()}`);
-		}
-		console.error(area.replace(/\t/g, '  '));
+		// let area = BNF.Message.HighlightArea(this.data, refStart, refEnd);
+		let area = helper.CodeSection(this.data, refStart, refEnd);
+		console.error(`\n${this.path}:\n ${msg}\n${area.replace(/\t/g, '  ')}`);
 		this.project.markError();
 	}
 

--- a/compiler/helper/error.js
+++ b/compiler/helper/error.js
@@ -1,0 +1,43 @@
+function FixStringLength(string, count, filler = " ") {
+	return filler.repeat(Math.max(0, count - string.length)) +
+		string.slice(0, count);
+}
+
+function CodeSection(string, refStart, refEnd) {
+	string = string.replace(/\t/g, "  ");
+
+	let offset = refStart.line;
+	let digits = refEnd.line.toString().length;
+
+	string = string.split('\n')
+		.slice(refStart.line-1, refEnd.line)
+		.map( (val, i) => ` ${FixStringLength((i+offset).toString(), digits)} | ${val}` );
+
+	if (string.length > 5) {
+		string = [
+			...string.slice(0, 2),
+			` ${FixStringLength("*", digits)} | `,
+			...string.slice(-2)
+		];
+	}
+
+	// let highlightA = " ".repeat(digits+2) + "|" +
+	// 	" ".repeat(refStart.col) +
+	// 	"^".repeat(string[0].length);
+
+	// let highlightB = " ".repeat(digits+2) + "|" +
+	// "^".repeat(refEnd.col);
+
+	// return [
+	// 	string[0],
+	// 	highlightA,
+	// 	...string.slice(1),
+	// 	highlightB
+	// ].join("\n");
+
+	return string.join('\n');
+}
+
+module.exports = {
+	CodeSection
+};


### PR DESCRIPTION
Error messages now embed a summarised code snippet of the affecting areas

E.g.
```
C:\Users\Ajani\Documents\GitHub\uniview-lang>uvc test.uv
Parsing: C:\Users\Ajani\Documents\GitHub\uniview-lang\test.uv
Parsing: C:\Users\Ajani\Documents\GitHub\uniview-lang\std\print.uv
Linking...
Processing...

C:\Users\Ajani\Documents\GitHub\uniview-lang\test.uv:
 Error: Unable to merge possible states at (20:8) due to
  'c' is undefined from (10:2)
 10 |   int c;
 11 |
  * |
 19 |
 20 |   print(c);

Uncompilable errors
```