### PR TITLE
Enchanced uint behaviour

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 
 ### Tweaks
 - [x] Primative numbers are 64bit by default
+- [x] Compiler now generates all IR in fragments before joining (will assist with template implementation)
 
 ## Version 0.0.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,9 +7,10 @@
 ### Fixes
 
 ### Tweaks
-- [x] Primative numbers are 64bit by default
-- [x] Compiler now generates all IR in fragments before joining (will assist with template implementation)
+- [x] Primative numbers are 64bit by default.
+- [x] Compiler now generates all IR in fragments before joining (will assist with template implementation).
 - [x] Changed ``sizeof`` function to being a compiled default non-inlined function.
+- [x] Changed primative function name ``static_cast`` to ``cast``.
 
 ## Version 0.0.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,10 @@
 ### Fixes
 
 ### Tweaks
-- [x] Primative numbers are 64bit by default.
+- [x] Primitive numbers are 64bit by default.
 - [x] Compiler now generates all IR in fragments before joining (will assist with template implementation).
 - [x] Changed ``sizeof`` function to being a compiled default non-inlined function.
-- [x] Changed primative function name ``static_cast`` to ``cast``.
+- [x] Changed primitive function name ``static_cast`` to ``cast``.
 
 ## Version 0.0.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Upcoming
+
+### Added
+
+### Fixes
+
+### Tweaks
+- [x] Primative numbers are 64bit by default
+
 ## Version 0.0.1
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 ### Tweaks
 - [x] Primative numbers are 64bit by default
 - [x] Compiler now generates all IR in fragments before joining (will assist with template implementation)
+- [x] Changed ``sizeof`` function to being a compiled default non-inlined function.
 
 ## Version 0.0.1
 

--- a/compiler/compile.js
+++ b/compiler/compile.js
@@ -75,11 +75,12 @@ if (project.error) {
 
 // Compile to LLVM
 console.info("Processing...");
-let asm = project.compile();
+project.compile();
 if (project.error) {
 	console.error("\nUncompilable errors");
 	process.exit(1);
 }
+let asm = project.toLLVM();
 
 
 if (config.verifyOnly) {

--- a/compiler/component/execution/expr.js
+++ b/compiler/component/execution/expr.js
@@ -22,7 +22,7 @@ class ExecutionExpr extends ExecutionBase {
 		let val = null;
 		switch (ast.tokens[0].type) {
 			case "float":
-				type = new TypeRef(0, Primative.types.float);
+				type = new TypeRef(0, Primative.types.double);
 				val = new LLVM.Constant(
 					ast.tokens[0].tokens,
 					ast.ref.start
@@ -36,7 +36,7 @@ class ExecutionExpr extends ExecutionBase {
 				);
 				break;
 			case "integer":
-				type = new TypeRef(0, Primative.types.i32);
+				type = new TypeRef(0, Primative.types.i64);
 				val = new LLVM.Constant(
 					ast.tokens[0].tokens,
 					ast.ref.start

--- a/compiler/component/execution/flow.js
+++ b/compiler/component/execution/flow.js
@@ -33,6 +33,9 @@ class ExecutionFlow extends ExecutionExpr {
 			new TypeRef(0, Primative.types.bool),
 			true
 		);
+		if (cond == null) {
+			return null;
+		}
 		if (cond.epilog.stmts.length > 0) {
 			throw new Error("Cannot do an if-statement using instruction with epilog");
 		}

--- a/compiler/component/file.js
+++ b/compiler/component/file.js
@@ -330,10 +330,24 @@ class File {
 
 
 	compile () {
+		for (let key in this.names) {
+			this.names[key].compile();
+		}
+	}
+
+
+	toLLVM () {
 		let fragment = new LLVM.Fragment();
 
 		for (let key in this.names) {
-			let res = this.names[key].compile();
+			if (
+				!(this.names[key] instanceof Structure) &&
+				this.names[key] instanceof TypeDef
+			) {
+				continue;
+			}
+
+			let res = this.names[key].toLLVM();
 			if (res instanceof LLVM.Fragment) {
 				fragment.merge(res);
 			} else {

--- a/compiler/component/function.js
+++ b/compiler/component/function.js
@@ -78,13 +78,17 @@ class Function {
 	}
 
 	compile () {
+		for (let instance of this.instances) {
+			instance.compile();
+		}
+	}
+
+	toLLVM() {
 		let fragment = new LLVM.Fragment();
 
 		for (let instance of this.instances) {
-			let ir = instance.compile();
-			if (ir) {
-				fragment.append(ir);
-			}
+			let ir = instance.toLLVM();
+			fragment.append(ir);
 		}
 
 		return fragment;

--- a/compiler/component/function_instance.js
+++ b/compiler/component/function_instance.js
@@ -201,7 +201,6 @@ class Function_Instance {
 
 		let gen = new Generator_ID(0);
 		frag.assign_ID(gen);
-		frag.flattern();
 
 		this.ir = frag;
 	}

--- a/compiler/component/function_instance.js
+++ b/compiler/component/function_instance.js
@@ -30,6 +30,9 @@ class Function_Instance {
 
 		this.name = ast.tokens[0].tokens[1].tokens;
 		this.represent = external ? `${this.name}` : `${this.name}.${this.ctx.getFileID().toString(36)}.${this.id.toString(36)}`;
+
+
+		this.ir = new LLVM.Fragment();
 	}
 
 	markExport () {
@@ -200,7 +203,12 @@ class Function_Instance {
 		frag.assign_ID(gen);
 		frag.flattern();
 
-		return frag;
+		this.ir = frag;
+	}
+
+
+	toLLVM() {
+		return this.ir;
 	}
 }
 

--- a/compiler/component/import.js
+++ b/compiler/component/import.js
@@ -79,7 +79,9 @@ class Import {
 		return;
 	}
 
-	compile () {
+	compile () {}
+
+	toLLVM () {
 		let frag = new LLVM.Fragment();
 		return frag;
 	}

--- a/compiler/component/project.js
+++ b/compiler/component/project.js
@@ -139,10 +139,16 @@ class Project {
 
 
 	compile () {
+		for (let file of this.files) {
+			file.compile();
+		}
+	}
+
+	toLLVM () {
 		let fragment = new LLVM.Fragment();
 
 		for (let file of this.files) {
-			let res = file.compile();
+			let res = file.toLLVM();
 			fragment.merge(res);
 		}
 

--- a/compiler/component/struct.js
+++ b/compiler/component/struct.js
@@ -16,6 +16,8 @@ class Struct_Term {
 		this.size = typeRef.pointer > 0 ? 4 : typeRef.type.size;
 
 		this.typeSystem = "linear";
+
+		this.ir = new LLVM.Fragment();
 	}
 
 	toLLVM() {
@@ -154,11 +156,15 @@ class Structure extends TypeDef {
 			types.push(this.terms[name].toLLVM());
 		}
 
-		return new LLVM.Struct(
+		this.ir = new LLVM.Struct(
 			new LLVM.Name(this.represent, false, this.ref),
 			types,
 			this.ref
 		);
+	}
+
+	toLLVM() {
+		return this.ir;
 	}
 
 

--- a/compiler/middle/compare.js
+++ b/compiler/middle/compare.js
@@ -3,7 +3,7 @@ const LLVM = require('./llvm.js');
 
 class Compare extends Instruction {
 	/**
-	 * @param {String} mode
+	 * @param {Number} mode {uint, int, float}
 	 * @param {String} condition
 	 * @param {LLVM.Type} type
 	 * @param {LLVM.Name} opperand_a

--- a/compiler/middle/llvm.js
+++ b/compiler/middle/llvm.js
@@ -29,6 +29,7 @@ const PtrToInt = require('./ptrtoint.js');
 const Raw = require('./raw.js');
 const Rem = require('./rem.js');
 const Return = require('./return.js');
+const Select = require('./select.js');
 const Set = require('./set.js');
 const Store = require('./store.js');
 const Struct = require('./struct.js');
@@ -55,7 +56,7 @@ module.exports = {
 	Phi, Procedure, PtrToInt,
 	Raw, Return,
 	Rem,
-	Set, Store, Struct, Sub,
+	Select, Set, Store, Struct, Sub,
 	Trunc, Type,
 	WPad,
 	XOr

--- a/compiler/middle/select.js
+++ b/compiler/middle/select.js
@@ -1,0 +1,28 @@
+const Instruction = require("./instruction.js");
+const LLVM = require('./llvm.js');
+
+
+class Select extends Instruction {
+	/**
+	 *
+	 * @param {LLVM.Argument} condition
+	 * @param {LLVM.Argument[]} results
+	 * @param {BNF_Reference?} ref
+	 */
+	constructor(condition, results, ref) {
+		super (ref);
+		this.condition = condition;
+		this.results = results;
+	}
+
+	flattern (indent) {
+		return super.flattern(
+			`select ` +
+			`${this.condition.flattern(0)}, ` +
+			this.results.map( x => x.flattern(0) ).join(", "),
+		indent);
+	}
+}
+
+
+module.exports = Select;

--- a/compiler/primative/array.js
+++ b/compiler/primative/array.js
@@ -45,6 +45,10 @@ class Template_Array extends Template {
 
 		return new TypeRef(0, inst);
 	}
+
+	toLLVM() {
+		return new LLVM.Fragment();
+	}
 }
 
 class Array_Gen extends TypeDef {

--- a/compiler/primative/blank.js
+++ b/compiler/primative/blank.js
@@ -30,7 +30,7 @@ class Template_Primative_Blank extends Template {
 
 		let type = template[0];
 
-		let func = new Function_Instance(this, "Blank", type.toLLVM(), signature);
+		let func = new Function_Instance(this, "Blank", type, signature);
 		func.generate = (regs, ir_args) => {
 			return {
 				preamble: new LLVM.Fragment(),
@@ -42,6 +42,10 @@ class Template_Primative_Blank extends Template {
 		};
 
 		return func;
+	}
+
+	toLLVM() {
+		return new LLVM.Fragment();
 	}
 }
 

--- a/compiler/primative/blank.js
+++ b/compiler/primative/blank.js
@@ -40,6 +40,7 @@ class Template_Primative_Blank extends Template {
 				type: type.duplicate().offsetPointer(1)
 			};
 		};
+		func.compile();
 
 		return func;
 	}

--- a/compiler/primative/function_instance.js
+++ b/compiler/primative/function_instance.js
@@ -53,7 +53,10 @@ class Function_Instance {
 
 	link () {}
 	match (other) {}
-	compile () {}
+	compile () {
+		let gen = new Generator_ID(this.signature.length + 1);
+		this.ir.assign_ID(gen);
+	}
 
 	toLLVM() {
 		return this.ir;

--- a/compiler/primative/function_instance.js
+++ b/compiler/primative/function_instance.js
@@ -18,6 +18,18 @@ class Function_Instance {
 
 		this.name = name;
 		this.represent = `${this.name}.${this.ctx.getFile().getID().toString(36)}.${this.id.toString(36)}`;
+
+
+		this.ir = new LLVM.Procedure (
+			returnType.toLLVM(),
+			new LLVM.Name(this.represent, true),
+			signature.map ((arg, i) => new LLVM.Argument(
+				arg.toLLVM(),
+				new LLVM.Name(i.toString(), false)
+			)),
+			"#1",
+			false
+		);
 	}
 
 	getFileID () {
@@ -42,6 +54,10 @@ class Function_Instance {
 	link () {}
 	match (other) {}
 	compile () {}
+
+	toLLVM() {
+		return this.ir;
+	}
 }
 
 module.exports = Function_Instance;

--- a/compiler/primative/main.js
+++ b/compiler/primative/main.js
@@ -27,7 +27,7 @@ function Generate (ctx) {
 	file.names.sizeof = new SizeOf(file);
 	file.names.Blank = new Blank(file);
 
-	file.names.Array = new Array_Template(file);
+	// file.names.Array = new Array_Template(file);
 
 	ctx.inject(file);
 }

--- a/compiler/primative/main.js
+++ b/compiler/primative/main.js
@@ -23,7 +23,7 @@ function Generate (ctx) {
 		file.names[name] = types[name];
 	}
 
-	file.names.static_cast = new Static_Cast(file);
+	file.names.cast = new Static_Cast(file);
 	file.names.sizeof = new SizeOf(file);
 	file.names.Blank = new Blank(file);
 

--- a/compiler/primative/sizeof.js
+++ b/compiler/primative/sizeof.js
@@ -27,19 +27,23 @@ class Template_Primative_Size_Of extends Template {
 			return false;
 		}
 
-		let func = new Function_Instance(this, "sizeof", types.i32.toLLVM(), []);
+		let func = new Function_Instance(this, "sizeof", types.i64, []);
 		func.generate = (regs, ir_args) => {
 			return {
 				preamble: new LLVM.Fragment(),
 				instruction: new LLVM.Argument(
-					types.i32.toLLVM(),
-					new LLVM.Constant(template[0].pointer > 0 ? 4 : template[0].type.size, null)
+					types.i64.toLLVM(),
+					new LLVM.Constant(template[0].pointer > 0 ? 8 : template[0].type.size, null)
 				),
 				type: new TypeRef(0, types.i32)
 			};
 		};
 
 		return func;
+	}
+
+	toLLVM() {
+		return new LLVM.Fragment();
 	}
 }
 

--- a/compiler/primative/sizeof.js
+++ b/compiler/primative/sizeof.js
@@ -8,42 +8,76 @@ const TypeRef = require('../component/typeRef.js');
 class Template_Primative_Size_Of extends Template {
 	constructor (ctx) {
 		super(ctx, null);
+
+		this.children = [];
+	}
+
+	findMatch(inputType) {
+		for (let child of this.children) {
+			if (child.type == inputType) {
+				return child.function;
+			}
+		}
+
+		return null;
 	}
 
 	getFunction (access, signature, template) {
-		return this.generate(access, signature, template);
+		if (access.length !== 0) {
+			return false;
+		}
+
+		// Check input lengths are correct
+		if (signature.length != 0 || template.length != 1) {
+			return false;
+		}
+
+		let inputType = template[0];
+		let outputType = new TypeRef(0, types.u64);
+		let match = this.findMatch(inputType);
+		if (match) {
+			return match;
+		}
+
+		let func = this.generate(inputType, outputType);
+		if (func) {
+			this.children.push({
+				type: inputType,
+				function: func
+			});
+
+			return func;
+		}
+
+		return false;
 	}
 
-	generate (access, signature, template) {
-		if (access.length != 0) {
-			return false;
-		}
+	generate (inputType, outputType) {
 
-		if (signature.length > 0) {
-			return false;
-		}
+		let func = new Function_Instance(this, "sizeof", outputType, []);
+		func.isInline = false;
 
-		if (template.length != 1) {
-			return false;
-		}
+		func.ir.append(new LLVM.Return(
+			new LLVM.Argument(
+				outputType.toLLVM(),
+				new LLVM.Constant(inputType.pointer > 0 ? 8 : inputType.type.size, null)
+			)
+		));
 
-		let func = new Function_Instance(this, "sizeof", types.i64, []);
-		func.generate = (regs, ir_args) => {
-			return {
-				preamble: new LLVM.Fragment(),
-				instruction: new LLVM.Argument(
-					types.i64.toLLVM(),
-					new LLVM.Constant(template[0].pointer > 0 ? 8 : template[0].type.size, null)
-				),
-				type: new TypeRef(0, types.i32)
-			};
-		};
+		func.compile();
 
 		return func;
 	}
 
-	toLLVM() {
-		return new LLVM.Fragment();
+	toLLVM () {
+		let frag = new LLVM.Fragment();
+
+		for (let child of this.children) {
+			let asm = child.function.toLLVM();
+			frag.append(asm);
+		}
+
+		return frag;
 	}
 }
 

--- a/compiler/primative/static_cast.js
+++ b/compiler/primative/static_cast.js
@@ -116,6 +116,8 @@ class Template_Primative_Static_Cast extends Template {
 			return false;
 		}
 
+		func.compile();
+
 		return func;
 	}
 

--- a/compiler/primative/static_cast.js
+++ b/compiler/primative/static_cast.js
@@ -23,6 +23,10 @@ class Template_Primative_Static_Cast extends Template {
 	}
 
 	getFunction (access, signature, template) {
+		if (access.length !== 0) {
+			return false;
+		}
+
 		// Check input lengths are correct
 		if (signature.length != 1 || template.length != 1) {
 			return false;
@@ -35,7 +39,7 @@ class Template_Primative_Static_Cast extends Template {
 			return match;
 		}
 
-		let func = this.generate(inputType, outputType, template);
+		let func = this.generate(inputType, outputType);
 		if (func) {
 			this.children.push({
 				input: inputType,

--- a/compiler/primative/types.js
+++ b/compiler/primative/types.js
@@ -130,7 +130,9 @@ for (let i=1; i<=8; i+=i) {
 
 // Bind float category
 types.float.cat  = "float";
+types.float.signed = true;
 types.double.cat = "float";
+types.double.signed = true;
 
 types.int   = types.i64;
 types.uint   = types.u64;

--- a/compiler/primative/types.js
+++ b/compiler/primative/types.js
@@ -132,14 +132,8 @@ for (let i=1; i<=8; i+=i) {
 types.float.cat  = "float";
 types.double.cat = "float";
 
-types.char  = types.i8;
-types.short = types.i16;
-types.int   = types.i32;
-types.long  = types.i64;
-types.uchar  = types.u8;
-types.ushort = types.u16;
-types.uint   = types.u32;
-types.ulong  = types.u64;
+types.int   = types.i64;
+types.uint   = types.u64;
 
 
 // Update primative types correct type system

--- a/std/experimental/time.uv
+++ b/std/experimental/time.uv
@@ -75,7 +75,7 @@ fn GetDate(unixTime: i64): Date {
 		t2 = -9;
 	}
 	let m = mp + t2;
-	// y = y + static_cast#[int](m <= 2);
+	// y = y + cast#[int](m <= 2);
 
 	date.day = d;
 	date.month = m;
@@ -86,7 +86,7 @@ fn GetDate(unixTime: i64): Date {
 }
 
 fn GetTime(unixTime: i64): Time {
-	let unix = static_cast#[int] (unixTime);
+	let unix = cast#[int] (unixTime);
 
 	let t = Blank#[Time]();
 	t.seconds = unix % 60;

--- a/std/experimental/time.uv
+++ b/std/experimental/time.uv
@@ -49,7 +49,7 @@ fn GetDate(unixTime: i64): Date {
 
 	let date = Blank#[Date]();
 
-	let s = static_cast#[i32](unixTime);
+	let s = unixTime;
 	let z = s/86400 + 719468;
 
 	let t1: int;

--- a/std/math.uv
+++ b/std/math.uv
@@ -67,7 +67,7 @@ fn abs(val: i8): i8 {
 }
 
 fn abs(val: double): double {
-	let zero = static_cast#[double](0.0);
+	let zero = cast#[double](0.0);
 	if (val < zero) {
 		return zero - val;
 	}

--- a/test/pre-alpha/cast.uv
+++ b/test/pre-alpha/cast.uv
@@ -1,23 +1,78 @@
 import "print.uv";
 
-fn TestSignatureWrap() {
-	let a = static_cast#[u8](-3);
-	let b = static_cast#[i32](a);
-	println(b);
 
-	return;
+fn CheckOverFlow(): int {
+	let a = static_cast#[u8](128);
+	let b = static_cast#[i8](a);
+
+	if (b != static_cast#[i8](127)) {
+		return 1;
+	}
+
+
+	a = static_cast#[u8](256);
+	b = static_cast#[i8](a);
+	if (b != static_cast#[i8](127)) {
+		return 1;
+	}
+
+
+	b = static_cast#[i8](1024);
+	if (b != static_cast#[i8](127)) {
+		return 1;
+	}
+
+	let c = static_cast#[i16](9223372036854780000);
+	if (c != static_cast#[i16](32767)) {
+		return 1;
+	}
+
+	let d = static_cast#[i32](9223372036854780000);
+	if (d != static_cast#[i32](2147483647)) {
+		return 1;
+	}
+
+	return 0;
+}
+
+fn CheckUnderflow(): int {
+	let a = static_cast#[i8](-1);
+	let b = static_cast#[u8](a);
+
+	if (b != static_cast#[u8](0)) {
+		return 1;
+	}
+
+
+	a = static_cast#[i8](0);
+	b = static_cast#[u8](a);
+	if (b != static_cast#[u8](0)) {
+		return 1;
+	}
+
+
+	b = static_cast#[u8](1024);
+	if (b != static_cast#[u8](0)) {
+		return 1;
+	}
+
+	return 0;
 }
 
 
 fn main (): int {
-	let a = 0;
+	let res = CheckOverFlow();
+	if (res == -1) {
+		println("Failed overflow check");
+		return 1;
+	}
 
-	let b = static_cast#[u8](a);
-	a = static_cast#[i64](b);
-	let c = static_cast#[float](a);
-	b = static_cast#[u8](c);
 
-	TestSignatureWrap();
+	res = CheckUnderflow();
+	if (res == -1) {
+		println("Failed underflow check");
+		return 1;
+	}
 
 	return 0;
 }

--- a/test/pre-alpha/cast.uv
+++ b/test/pre-alpha/cast.uv
@@ -2,33 +2,33 @@ import "print.uv";
 
 
 fn CheckOverFlow(): int {
-	let a = static_cast#[u8](128);
-	let b = static_cast#[i8](a);
+	let a = cast#[u8](128);
+	let b = cast#[i8](a);
 
-	if (b != static_cast#[i8](127)) {
+	if (b != cast#[i8](127)) {
 		return 1;
 	}
 
 
-	a = static_cast#[u8](256);
-	b = static_cast#[i8](a);
-	if (b != static_cast#[i8](127)) {
+	a = cast#[u8](256);
+	b = cast#[i8](a);
+	if (b != cast#[i8](127)) {
 		return 1;
 	}
 
 
-	b = static_cast#[i8](1024);
-	if (b != static_cast#[i8](127)) {
+	b = cast#[i8](1024);
+	if (b != cast#[i8](127)) {
 		return 1;
 	}
 
-	let c = static_cast#[i16](9223372036854780000);
-	if (c != static_cast#[i16](32767)) {
+	let c = cast#[i16](9223372036854780000);
+	if (c != cast#[i16](32767)) {
 		return 1;
 	}
 
-	let d = static_cast#[i32](9223372036854780000);
-	if (d != static_cast#[i32](2147483647)) {
+	let d = cast#[i32](9223372036854780000);
+	if (d != cast#[i32](2147483647)) {
 		return 1;
 	}
 
@@ -36,23 +36,23 @@ fn CheckOverFlow(): int {
 }
 
 fn CheckUnderflow(): int {
-	let a = static_cast#[i8](-1);
-	let b = static_cast#[u8](a);
+	let a = cast#[i8](-1);
+	let b = cast#[u8](a);
 
-	if (b != static_cast#[u8](0)) {
+	if (b != cast#[u8](0)) {
 		return 1;
 	}
 
 
-	a = static_cast#[i8](0);
-	b = static_cast#[u8](a);
-	if (b != static_cast#[u8](0)) {
+	a = cast#[i8](0);
+	b = cast#[u8](a);
+	if (b != cast#[u8](0)) {
 		return 1;
 	}
 
 
-	b = static_cast#[u8](1024);
-	if (b != static_cast#[u8](0)) {
+	b = cast#[u8](1024);
+	if (b != cast#[u8](0)) {
 		return 1;
 	}
 

--- a/test/pre-alpha/cast.uv
+++ b/test/pre-alpha/cast.uv
@@ -10,10 +10,10 @@ fn TestSignatureWrap() {
 
 
 fn main (): int {
-	let a: i32 = 0;
+	let a = 0;
 
 	let b = static_cast#[u8](a);
-	a = static_cast#[i32](b);
+	a = static_cast#[i64](b);
 	let c = static_cast#[float](a);
 	b = static_cast#[u8](c);
 

--- a/test/pre-alpha/library-behaviour.uv
+++ b/test/pre-alpha/library-behaviour.uv
@@ -6,8 +6,8 @@ import "print.uv" as std; // check name-space access
 
 fn main(): int {
 	let a: int;
-	let b: i32;
-	let c: i32;
+	let b: i64;
+	let c: i64;
 
 	a = 1;
 	b = 2;


### PR DESCRIPTION
- [x] Primitive numbers are 64bit by default.
- [x] Compiler now generates all IR in fragments before joining (will assist with template implementation).
- [x] Changed ``sizeof`` function to being a compiled default non-inlined function.
- [x] Changed primitive function name ``static_cast`` to ``cast``.
- [x] Fixed being unable to safely cast between signed and non signed integers
- [x] Added automated test to check under and overflow for casting

