### PR TITLE
Resolution based gep

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 - [x] Compiler now generates all IR in fragments before joining (will assist with template implementation).
 - [x] Changed ``sizeof`` function to being a compiled default non-inlined function.
 - [x] Changed primitive function name ``static_cast`` to ``cast``.
+- [x] Probabilities are now used to represent loading structure values (GEPs) to remove irrelevant code and clean up the compiler code base.
 
 ## Version 0.0.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixes
+- [x] Fixed being unable to use structure access chaining ``a.b.c``
 
 ### Tweaks
 - [x] Primitive numbers are 64bit by default.

--- a/compiler/component/execution/base.js
+++ b/compiler/component/execution/base.js
@@ -124,7 +124,7 @@ class ExecutionBase {
 			preamble.append(res.preamble);
 			res = res.variable;
 
-			access.splice(0, 2);
+			access.splice(0, 1);
 		}
 
 		return {

--- a/compiler/component/execution/base.js
+++ b/compiler/component/execution/base.js
@@ -103,6 +103,8 @@ class ExecutionBase {
 	 * @param {Boolean} read
 	 */
 	getVar (ast, read = true) {
+		let preamble = new LLVM.Fragment();
+
 		// Link dynamic access arguments
 		ast = this.resolveAccess (ast);
 		let res = this.scope.getVar (ast, read);
@@ -113,7 +115,6 @@ class ExecutionBase {
 			return res;
 		}
 
-		let preamble = new LLVM.Fragment();
 		let access = ast.tokens[2];
 		while (access.length > 0) {
 			res.hasUpdated = res.hasUpdated || !read;
@@ -121,7 +122,7 @@ class ExecutionBase {
 			if (res.error) {
 				return res;
 			}
-			preamble.append(res.preamble);
+			preamble.merge(res.preamble);
 			res = res.variable;
 
 			access.splice(0, 1);

--- a/compiler/component/execution/expr.js
+++ b/compiler/component/execution/expr.js
@@ -46,8 +46,10 @@ class ExecutionExpr extends ExecutionBase {
 				let bytes = ast.tokens[0].tokens[1].length + 1;
 				let str = ast.tokens[0].tokens[1].replace(/\"/g, "\\22").replace(/\n/g, '\\0A') + "\\00";
 
+				type = new TypeRef(0, Primative.types.string);
+
 				let ir_t1 = new LLVM.Type(`[ ${bytes} x i8 ]`, 0, ast.ref);
-				let ir_t2 = new LLVM.Type(`i8`, 1);
+				let ir_t2 = type.toLLVM();
 
 				let str_id = new LLVM.ID();
 				let ptr_id = new LLVM.ID();
@@ -86,7 +88,6 @@ class ExecutionExpr extends ExecutionBase {
 					ast.ref
 				));
 
-				type = new TypeRef(1, Primative.types.string);
 				val = new LLVM.Name(ptr_id, false, ast.ref);
 				break;
 			default:
@@ -95,7 +96,7 @@ class ExecutionExpr extends ExecutionBase {
 
 		return {
 			instruction: new LLVM.Argument(
-				new LLVM.Type(type.type.represent, type.pointer, ast.ref.start),
+				type.toLLVM(),
 				val,
 				ast.ref
 			),

--- a/compiler/component/execution/index.js
+++ b/compiler/component/execution/index.js
@@ -384,38 +384,9 @@ class Execution extends ExecutionFlow {
 			returnType = res.type;
 			frag.merge(res.preamble);
 			if (returnType.type.typeSystem == "linear") {
-				// Structures are parsed by pointer
 
-				let sizePtrID = new LLVM.ID();
-				frag.append(new LLVM.Set(
-					new LLVM.Name(sizePtrID, false, ast.ref),
-					new LLVM.GEP(
-						returnType.duplicate().offsetPointer(-1).toLLVM(),
-						new LLVM.Argument(
-							returnType.duplicate().toLLVM(),
-							new LLVM.Constant("null", ast.ref),
-							ast.ref
-						),
-						[new LLVM.Argument(
-							new LLVM.Type("i64", 0, ast.ref),
-							new LLVM.Constant("1", ast.ref),
-							ast.ref
-						)]
-					)
-				));
-
-				let sizeID = new LLVM.ID();
-				frag.append(new LLVM.Set(
-					new LLVM.Name(sizeID, false, ast.ref),
-					new LLVM.PtrToInt(
-						new LLVM.Type("i64", 0),
-						new LLVM.Argument(
-							returnType.duplicate().toLLVM(),
-							new LLVM.Name(sizePtrID.reference(), false, ast.ref),
-							ast.ref
-						)
-					)
-				));
+				let size = returnType.type.sizeof(ast.ref);
+				frag.append(size.preamble);
 
 				let fromID = new LLVM.ID();
 				frag.append(new LLVM.Set(
@@ -450,10 +421,7 @@ class Execution extends ExecutionFlow {
 							new LLVM.Type("i8", 1),
 							new LLVM.Name(fromID.reference(), false)
 						),
-						new LLVM.Argument(
-							new LLVM.Type("i64", 0),
-							new LLVM.Name(sizeID.reference(), false)
-						),
+						size.instruction,
 						new LLVM.Argument(
 							new LLVM.Type('i1', 0),
 							new LLVM.Constant("0")

--- a/compiler/component/execution/index.js
+++ b/compiler/component/execution/index.js
@@ -222,7 +222,7 @@ class Execution extends ExecutionFlow {
 			let id = new LLVM.ID();
 			preamble.append(new LLVM.Set(
 				new LLVM.Name(id, false, ast.ref),
-				new LLVM.Alloc(target.returnType.duplicate().offsetPointer().toLLVM(), ast.ref),
+				new LLVM.Alloc(target.returnType.toLLVM(), ast.ref),
 				ast.ref
 			));
 

--- a/compiler/component/function_instance.js
+++ b/compiler/component/function_instance.js
@@ -84,10 +84,6 @@ class Function_Instance {
 			let search = exec.resolveType(type);
 			if (search instanceof TypeRef) {
 				search.pointer = type.tokens[0]; // Copy the pointer level across
-
-				if (search.type.typeSystem == "linear") {
-					search.offsetPointer(1);
-				}
 				search.lent = borrows[i];
 
 				this.signature.push(search);

--- a/compiler/component/memory/scope.js
+++ b/compiler/component/memory/scope.js
@@ -58,7 +58,7 @@ class Scope {
 
 			// Creation of namespace
 			this.variables[arg.name] = new Variable(
-				arg.type.duplicate().offsetPointer(0),
+				arg.type.duplicate(),
 				arg.name,
 				arg.ref
 			);

--- a/compiler/component/struct.js
+++ b/compiler/component/struct.js
@@ -225,7 +225,7 @@ class Structure extends TypeDef {
 		let storeID = new LLVM.ID();
 		preamble.append(new LLVM.Set(
 			new LLVM.Name(storeID, false),
-			new LLVM.Alloc(type.duplicate().offsetPointer(-1).toLLVM())
+			new LLVM.Alloc(type.toLLVM())
 		));
 		let instruction = new LLVM.Argument(
 			type.toLLVM(),

--- a/compiler/component/typeRef.js
+++ b/compiler/component/typeRef.js
@@ -66,8 +66,14 @@ class TypeRef {
 		return ( this.lent ? "@" : "$" ) + this.type.name;
 	}
 
-	toLLVM (ref = null) {
-		return new LLVM.Type(this.type.represent, this.pointer, ref);
+	toLLVM (ref = null, flat = false, pointer = false) {
+		return new LLVM.Type(
+			this.type.represent,
+			flat ? 0 :
+				pointer ? 1 :
+				this.lent || this.type.typeSystem == "linear" ? 1 : 0,
+			ref
+		);
 	}
 }
 

--- a/compiler/component/typedef.js
+++ b/compiler/component/typedef.js
@@ -50,5 +50,22 @@ class TypeDef {
 	toLLVM () {
 		return new LLVM.Type(this.represent, 0, this.declared || null);
 	}
+
+	/**
+	* Generates the code to determine the size of the structure
+	* @param {BNF_Reference} ref
+	* @returns
+	*/
+	sizeof (ref) {
+		return {
+			preamble: new LLVM.Fragment(),
+			instruction: new LLVM.Argument(
+				new LLVM.Type("i64"),
+				new LLVM.Constant(this.size),
+				ref
+			)
+		};
+	}
 }
+
 module.exports = TypeDef;

--- a/compiler/middle/alloc.js
+++ b/compiler/middle/alloc.js
@@ -9,6 +9,8 @@ class Alloc extends Instruction {
 	constructor(type, ref) {
 		super (ref);
 		this.type = type;
+
+		type.pointer -= 1;
 	}
 
 	flattern(indent) {

--- a/compiler/middle/latent.js
+++ b/compiler/middle/latent.js
@@ -35,11 +35,9 @@ class Latent extends Instruction {
 	}
 
 	flattern(indent) {
-		return super.flattern(
-			this.active ?
-				this.action.flattern() :
-				"; Disabled latent action",
-		indent);
+		return this.active ?
+			this.action.flattern(indent) :
+			super.flattern("; Disabled latent action", indent);
 	}
 }
 

--- a/compiler/middle/type.js
+++ b/compiler/middle/type.js
@@ -14,6 +14,15 @@ class Type extends Instruction {
 		this.pointer = pointerDepth;
 	}
 
+	duplicate() {
+		return new Type(this.term, this.pointer, this.ref);
+	}
+
+	offsetPointer(inc = 1) {
+		this.pointer += inc;
+		return this;
+	}
+
 	flattern(indent) {
 		let lvl = "";
 		for (let i=0; i<this.pointer; i++) {

--- a/compiler/primative/blank.js
+++ b/compiler/primative/blank.js
@@ -37,7 +37,7 @@ class Template_Primative_Blank extends Template {
 				instruction: new LLVM.Alloc(
 					type.toLLVM()
 				),
-				type: type.duplicate().offsetPointer(1)
+				type: type.duplicate()
 			};
 		};
 		func.compile();

--- a/test/pre-alpha/struct.uv
+++ b/test/pre-alpha/struct.uv
@@ -1,9 +1,35 @@
 import "print.uv";
 
+// Keep this function before struct definition:
+//  - checks out of order declaration is working
+//  - checks storing structs within structs
+fn check(target: @Person, id: int, age: int, finger: int): int {
+	if (target.id != id) {
+		return 1;
+	}
+	if (target.age != age) {
+		return 1;
+	}
+	let f = target.finger;
+	if (f.id != finger) {
+		return 1;
+	}
+	target.finger = f;
+
+	return 0;
+}
+
+
+struct FingerPrint {
+	id: int;
+}
+
 struct Person {
 	id: int;
 	age: int;
+	finger: FingerPrint;
 }
+
 
 
 fn init(ofAge: bool): Person {
@@ -15,6 +41,9 @@ fn init(ofAge: bool): Person {
 	}
 
 	p.id = 0;
+	p.finger = Blank#[FingerPrint]();
+	p.finger.id = 1;
+
 	return p;
 }
 
@@ -28,43 +57,58 @@ fn print(p: Person) {
 	print(p.id);
 	print(", age: ");
 	print(p.age);
-	println(" }");
+	print(", finger: ");
+	print(p.finger);
+	print(" }");
+
+	return;
+}
+fn print(f: FingerPrint) {
+	print("FingerPrint { id: ");
+	print(f.id);
+	print(" }");
 
 	return;
 }
 
 
+
 fn main(): int {
 	let p = init(false);
-	let b = $p;
+	if (check(@p, 0, 16, 1) == 1) {
+		println("Failed init test");
+		return 1;
+	}
+
+
+	p = init(true);
+	if (check(@p, 0, 21, 1) == 1) {
+		println("Failed init test");
+		return 1;
+	}
+
+	let q = $p;
+	if (check(@q, 0, 21, 1) == 1) {
+		println("Failed clone test");
+		return 1;
+	}
+
 	age(@p);
-	print(p);
-	print(b);
+	if (check(@p, 0, 22, 1) == 1) {
+		println("Failed clone independence test");
+		return 1;
+	}
+	if (check(@q, 0, 21, 1) == 1) {
+		println("Failed clone independence test");
+		return 1;
+	}
+
+
+	p.finger = Blank#[FingerPrint]();
+	if (check(@p, 0, 22, 1) != 1) {
+		println("Failed changing sub structure");
+		return 1;
+	}
 
 	return 0;
-}
-
-
-
-
-// Test structs defined out of order
-import "print.uv";
-
-fn Test(): int {
-	print("cat");
-	let c = Blank#[Cat]();
-
-	let name = c.name;
-	print(name.placeholder);
-
-	return 0;
-}
-
-struct Name {
-	placeholder: i64;
-}
-
-struct Cat {
-	name: Name;
-	age: int;
 }

--- a/test/pre-alpha/struct.uv
+++ b/test/pre-alpha/struct.uv
@@ -77,6 +77,8 @@ fn main(): int {
 	let p = init(false);
 	if (check(@p, 0, 16, 1) == 1) {
 		println("Failed init test");
+		print(p);
+		print(" != Person { id: 0, age: 16, finger: Finger Print { id: 1 } }");
 		return 1;
 	}
 
@@ -84,22 +86,30 @@ fn main(): int {
 	p = init(true);
 	if (check(@p, 0, 21, 1) == 1) {
 		println("Failed init test");
+		print(p);
+		print(" != Person { id: 0, age: 21, finger: Finger Print { id: 1 } }");
 		return 1;
 	}
 
 	let q = $p;
 	if (check(@q, 0, 21, 1) == 1) {
 		println("Failed clone test");
+		print(q);
+		print(" != Person { id: 0, age: 21, finger: Finger Print { id: 1 } }");
 		return 1;
 	}
 
 	age(@p);
 	if (check(@p, 0, 22, 1) == 1) {
 		println("Failed clone independence test");
+		print(p);
+		print(" != Person { id: 0, age: 22, finger: Finger Print { id: 1 } }");
 		return 1;
 	}
 	if (check(@q, 0, 21, 1) == 1) {
 		println("Failed clone independence test");
+		print(q);
+		print(" != Person { id: 0, age: 21, finger: Finger Print { id: 1 } }");
 		return 1;
 	}
 
@@ -107,6 +117,8 @@ fn main(): int {
 	p.finger = Blank#[FingerPrint]();
 	if (check(@p, 0, 22, 1) != 1) {
 		println("Failed changing sub structure");
+		print(p);
+		print(" != Person { id: 0, age: 21, finger: Finger Print { id: 1 } }");
 		return 1;
 	}
 


### PR DESCRIPTION
### Fixes
- [x] Fixed being unable to use structure access chaining ``a.b.c``

### Tweaks
- [x] Probabilities are now used to represent loading structure values (GEPs) to remove irrelevant code and clean up the compiler codebase.
- [x] Cleaned up the codebase to remove now irrelevant ``.offsetPointer`` function calls

