### PR TITLE
Fix primitive template reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ You can also find a few examples in `test/pre-alpha/`.
 | `--execute` | Executes the binary output after successful compilation |
 | `--version` | Prints the version of the compiler |
 | `--verifyOnly` | Compiles to LLVM, but does not store the results or compiles further |
+| `--compileOnly` | Compiles to binary, but does not execute the result |
 | `--opt {num}` | Runs optimisation passes over the output (any number between 0-3 inclusive) |

--- a/compiler/primative/sizeof.js
+++ b/compiler/primative/sizeof.js
@@ -14,7 +14,7 @@ class Template_Primative_Size_Of extends Template {
 
 	findMatch(inputType) {
 		for (let child of this.children) {
-			if (child.type == inputType) {
+			if (child.type.match(inputType)) {
 				return child.function;
 			}
 		}

--- a/compiler/primative/static_cast.js
+++ b/compiler/primative/static_cast.js
@@ -14,7 +14,7 @@ class Template_Primative_Static_Cast extends Template {
 
 	findMatch(inputType, outputType) {
 		for (let child of this.children) {
-			if (child.input == inputType && child.output == outputType) {
+			if (child.input.match(inputType) && child.output.match(outputType)) {
 				return child.function;
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
 		"node": ">=14"
 	},
 	"dependencies": {
-		"bnf-parser": "^2.2.1"
+		"bnf-parser": "^2.2.5"
 	},
-	"devDependencies": {},
 	"scripts": {
 		"setup": "npm install && npm run build",
 		"start": "node compiler/compile.js",


### PR DESCRIPTION
Primitive functions which utilised templates were generating new functions instead of reusing already generated solutions.