### PR TITLE
Direct LLVM tool chain usage

### DIFF
--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -24,11 +24,11 @@ jobs:
         path: |
           C:/Program Files/LLVM
           ./llvm
-        key: llvm-12.0
+        key: llvm-12.0.1
     - name: Install LLVM and Clang
       uses: KyleMayes/install-llvm-action@v1
       with:
-        version: "3.5"
+        version: "12.0.1"
         cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
     - uses: actions/checkout@v2

--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -7,13 +7,6 @@ on:
     branches: [ main, dev, staging ]
 
 jobs:
-  cache:
-    uses: actions/cache@v2
-    with:
-      path: |
-        C:/Program Files/LLVM
-        ./llvm
-      key: llvm-3.5
   build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -1,5 +1,11 @@
 name: Execution
 
+on:
+  push:
+    branches: [ main, dev, staging ]
+  pull_request:
+    branches: [ main, dev, staging ]
+
 jobs:
   cache:
     uses: actions/cache@v2

--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -37,5 +37,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm run build --if-present
     - run: npm run test

--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -37,4 +37,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm run test
+    - run: node ./compiler/test.js --action

--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -1,12 +1,13 @@
 name: Execution
 
-on:
-  push:
-    branches: [ main, dev, staging ]
-  pull_request:
-    branches: [ main, dev, staging ]
-
 jobs:
+  cache:
+    uses: actions/cache@v2
+    with:
+      path: |
+        C:/Program Files/LLVM
+        ./llvm
+      key: llvm-3.5
   build:
 
     runs-on: ubuntu-latest
@@ -17,6 +18,20 @@ jobs:
         node-version: [ 14.x ]
 
     steps:
+    - name: Cache LLVM and Clang
+      id: cache-llvm
+      uses: actions/cache@v2
+      with:
+        path: |
+          C:/Program Files/LLVM
+          ./llvm
+        key: llvm-12.0
+    - name: Install LLVM and Clang
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "3.5"
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2

--- a/compiler/compile.js
+++ b/compiler/compile.js
@@ -26,17 +26,16 @@ if (process.argv.includes("--version")) {
 let config = {
 	output: path.basename(process.argv[2], path.extname(process.argv[2])) || "out",
 	source: false,
-	execute: true,
+	execute: process.argv.includes('--execute'),
 	compileOnly: false,
 	verifyOnly: false,
+	manualTooling: os.platform() == "win32" || process.argv.includes('--manualtooling'),
 	optimisation: "0",
 };
+
 let index = process.argv.indexOf('-o');
 if (index != -1 && index > 2) {
 	config.output = process.argv[index+1] || "out";
-}
-if (process.argv.includes('--execute')) {
-	config.execute = true;
 }
 if (process.argv.includes('--verifyOnly')) {
 	config.verifyOnly = true;
@@ -114,8 +113,10 @@ if (config.source == "llvm") {
 ------------------------------------------*/
 console.info("Compiling...");
 
-
-let platSP = os.platform() == "win32" ? path.resolve(__dirname, '../tools/') + "\\" : "";
+let platSP = config.manualTooling ?
+	path.resolve(__dirname, '../llvm/') +
+		(os.platform() == "win32" ? "\\" : "/") :
+	"";
 let exec_out = "./" + config.output;
 if (config.source == "asm") {
 	exec_out += ".s";

--- a/compiler/compile.js
+++ b/compiler/compile.js
@@ -114,7 +114,6 @@ if (config.source == "llvm") {
 ------------------------------------------*/
 console.info("Compiling...");
 
-// llvm\bin\llvm-link runtime\runtime.ll out.ll | llvm\bin\opt -enable-coroutines -O0 | clang -x ir -
 
 let platSP = os.platform() == "win32" ? path.resolve(__dirname, '../tools/') + "\\" : "";
 let exec_out = "./" + config.output;

--- a/compiler/compile.js
+++ b/compiler/compile.js
@@ -26,7 +26,7 @@ if (process.argv.includes("--version")) {
 let config = {
 	output: path.basename(process.argv[2], path.extname(process.argv[2])) || "out",
 	source: false,
-	execute: process.argv.includes('--execute'),
+	execute: true,
 	compileOnly: false,
 	verifyOnly: false,
 	manualTooling: os.platform() == "win32" || process.argv.includes('--manualtooling'),
@@ -44,6 +44,9 @@ if (process.argv.includes('--verifyOnly')) {
 if (process.argv.includes('--compileOnly')) {
 	config.compileOnly = true;
 	config.execute = false;
+}
+if (process.argv.includes('--execute')) {
+	config.execute = true;
 }
 index = process.argv.indexOf('-s');
 if (index != -1) {
@@ -102,9 +105,9 @@ if (config.verifyOnly) {
 }
 
 
+// Emmit source
 if (config.source == "llvm") {
 	fs.writeFileSync(`${config.output}.ll`, asm.flattern(), 'utf8');
-	process.exit(0);
 }
 
 
@@ -144,10 +147,11 @@ let compilation = exec(command, () => {
 
 			app.on('close', (code) => {
 				if (code === null) {
-					console.error(app.signalCode);
+					console.error('SEGFAULT', app.signalCode);
 					process.exit(1);
 				}
 
+				console.log(`Exited code ${code}`);
 				process.exit(code);
 			});
 		} else {

--- a/compiler/component/file.js
+++ b/compiler/component/file.js
@@ -288,12 +288,6 @@ class File {
 			case "llvm":
 				type = "--language=ir";
 				break;
-			case "cpp":
-				type = "--language=c++";
-				break;
-			case "c":
-				type = "--language=c";
-				break;
 			default:
 				this.throw(
 					`Error: Cannot include file, unable to handle include type ${type}`,

--- a/compiler/parser/build.js
+++ b/compiler/parser/build.js
@@ -1,3 +1,5 @@
+console.info("Building Syntax...");
+
 const BNF = require('bnf-parser');
 const fs = require('fs');
 

--- a/compiler/test.js
+++ b/compiler/test.js
@@ -8,7 +8,8 @@ const path = require('path');
 
 let flags = {
 	clang: process.argv.includes('--bin'),
-	exec: process.argv.includes('--exec')
+	exec: process.argv.includes('--exec'),
+	action: process.argv.includes('--action')
 };
 if (flags.exec) {
 	flags.clang = true;
@@ -44,7 +45,7 @@ function Compile(filename, id) {
 		let start = Date.now();
 		let compile = spawn(`node`, [
 			"compiler/compile.js", target,
-			"-o", `./test/temp/${id}`
+			"-o", `./test/temp/${id}`, flags.action ? "--manualtooling" : "--automatictooling"
 		].concat(extraArgs), {
 			cwd: path.resolve(__dirname, "../")
 		});

--- a/compiler/test.js
+++ b/compiler/test.js
@@ -107,7 +107,7 @@ async function Test () {
 	await Promise.all(tasks);
 
 	console.info(`\nFailed ${fails} of ${tests.length}`);
-	console.info(` Total Time: ${totalDuration.toFixed(3)}s`);
+	console.info(` Total Compute Time: ${totalDuration.toFixed(3)}s`);
 
 	if (fails > 0) {
 		process.exit(1);

--- a/install-tools.js
+++ b/install-tools.js
@@ -64,15 +64,15 @@ async function InstallTools() {
 		console.info("  Downloading tools from https://github.com/qupa-project/uniview-lang/releases/tag/tools")
 		await Download(
 			'https://github.com/qupa-project/uniview-lang/releases/download/tools/tools.zip',
-			'./tools/tools.zip'
+			'./llvm/tools.zip'
 		);
 
 		console.info("  Unzipping tools...");
-		await Unzip('./tools/tools.zip', './tools/');
+		await Unzip('./llvm/tools.zip', './llvm/');
 
 		console.info("  Installation complete");
 		console.info("  Running cleanup");
-		fs.unlinkSync('./tools/tools.zip');
+		fs.unlinkSync('./llvm/tools.zip');
 	}
 }
 

--- a/install-tools.js
+++ b/install-tools.js
@@ -1,0 +1,80 @@
+const unzipper = require('unzipper');
+const https = require('https');
+const fs = require('fs');
+const os = require('os');
+
+/**
+ * Download a resource from `url` to `dest`.
+ * @param {string} url - Valid URL to attempt download of resource
+ * @param {string} dest - Valid path to save the file.
+ * @returns {Promise<void>} - Returns asynchronously when successfully completed download
+ */
+function Download(url, dest) {
+	return new Promise((resolve, reject) => {
+		// Check file does not exist yet before hitting network
+		fs.access(dest, fs.constants.F_OK, (err) => {
+
+				if (err === null) reject('File already exists');
+
+				const request = https.get(url, response => {
+						if (response.statusCode === 200) {
+
+							const file = fs.createWriteStream(dest, { flags: 'wx' });
+							file.on('finish', () => resolve());
+							file.on('error', err => {
+								file.close();
+								if (err.code === 'EEXIST') reject('File already exists');
+								else fs.unlink(dest, () => reject(err.message)); // Delete temp file
+							});
+							response.pipe(file);
+						} else if (response.statusCode === 302 || response.statusCode === 301) {
+							//Recursively follow redirects, only a 200 will resolve.
+							Download(response.headers.location, dest).then(resolve);
+						} else {
+							reject(`Server responded with ${response.statusCode}: ${response.statusMessage}`);
+						}
+					});
+
+					request.on('error', err => {
+						reject(err.message);
+					});
+		});
+	});
+}
+
+
+function Unzip(from, to) {
+	return new Promise((res, rej) => {
+		let stream = fs.createReadStream(from);
+		stream.pipe(unzipper.Extract({path: to}));
+		stream.on('close', res);
+	});
+}
+
+
+
+
+async function InstallTools() {
+	console.info("Installing Tools...");
+
+	if (os.platform() == "win32") {
+		console.info("  The Windows version of LLVM does not contain certain prebuilt required tools");
+		console.info("  Now locally installing tools for use");
+
+		console.info("  Downloading tools from https://github.com/qupa-project/uniview-lang/releases/tag/tools")
+		await Download(
+			'https://github.com/qupa-project/uniview-lang/releases/download/tools/tools.zip',
+			'./tools/tools.zip'
+		);
+
+		console.info("  Unzipping tools...");
+		await Unzip('./tools/tools.zip', './tools/');
+
+		console.info("  Installation complete");
+		console.info("  Running cleanup");
+		fs.unlinkSync('./tools/tools.zip');
+	}
+}
+
+InstallTools()
+	.catch(console.error);

--- a/llvm/.gitignore
+++ b/llvm/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"node": ">=14"
 	},
 	"dependencies": {
-		"bnf-parser": "^2.2.5"
+		"bnf-parser": "^2.2.5",
+		"unzipper": "^0.10.11"
 	},
 	"scripts": {
 		"setup": "npm install && npm run build",
@@ -19,7 +20,8 @@
 		"test-translation": "node compiler/test.js",
 		"test-compilation": "node compiler/test.js --bin",
 		"test-execution": "node compiler/test.js --bin --exec",
-		"postinstall": "npm run build",
+		"install-tools": "node install-tools.js",
+		"postinstall": "npm run install-tools & npm run build",
 		"build": "npm run build-syntax && npm run build-runtime",
 		"build-syntax": "node compiler/parser/build.js",
 		"build-runtime": "clang++ runtime/runtime.cpp -S -emit-llvm -o runtime/runtime.ll"

--- a/test/pre-alpha/compare.uv
+++ b/test/pre-alpha/compare.uv
@@ -11,20 +11,34 @@ fn CompareFloats() {
 	return;
 }
 
-fn CompareInts() {
+fn CompareInts(): bool {
 	let a = 3;
 	let b = 7;
 
 	let c = a == b;
-	c = a != b;
-	c = a > b;
-	c = a < b;
-	c = a >= b;
-	c = a <= b;
-	return;
+	if (a == b) {
+		return false;
+	}
+	if (4 < 3) {
+		return false;
+	}
+	if (a > b) {
+		return false;
+	}
+	if (4 >= 5) {
+		return false;
+	}
+	if (5 <= 4) {
+		return false;
+	}
+	if (1 != 1) {
+		return false;
+	}
+
+	return true;
 }
 
-fn CompareBools () {
+fn CompareBools (): bool {
 	let a = true;
 	let b = false;
 
@@ -32,13 +46,32 @@ fn CompareBools () {
 	c = a || b;
 	c = a && b;
 
-	return;
+	if ((true || false) != true) {
+		return false;
+	}
+	if (true && false != false) {
+		return false;
+	}
+	if (true && true != true) {
+		return false;
+	}
+	if (!true == true) {
+		return false;
+	}
+
+	return true;
 }
 
 fn main(): int {
 	CompareFloats();
-	CompareInts();
-	CompareBools();
+
+
+	if (CompareInts() == false) {
+		return 1;
+	}
+	if (CompareBools() == false) {
+		return 1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Now directly uses the LLVM tool chain instead of relying on clang throughout.
This enables future coroutine support.
However we still currently rely on clang to do the final stage of compilation due to LLC only producing ASM not an assembled binary.